### PR TITLE
CD-183087 master: upgrade librdkafka to release 1.2.2-RC1

### DIFF
--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,7 +1,7 @@
 module Rdkafka
   VERSION = '0.6.0-c4'.freeze
-  LIBRDKAFKA_VERSION = '1.3.0'.freeze
+  LIBRDKAFKA_VERSION = '1.2.2-RC1'.freeze
   # SHA256 checksum for tar.gz can be found here https://github.com/edenhill/librdkafka/releases
   LIBRDKAFKA_SOURCE_SHA256 =
-    '465cab533ebc5b9ca8d97c90ab69e0093460665ebaf38623209cf343653c76d2'.freeze
+    'd44046cd6cf03fbcdf3f776feddc9c972e67a5dd28ac7ebabed43dbf0b2379ca'.freeze
 end

--- a/lib/rdkafka/version.rb
+++ b/lib/rdkafka/version.rb
@@ -1,5 +1,7 @@
 module Rdkafka
-  VERSION = "0.6.0-c3"
-  LIBRDKAFKA_VERSION = "1.1.0"
-  LIBRDKAFKA_SOURCE_SHA256 = "123b47404c16bcde194b4bd1221c21fdce832ad12912bd8074f88f64b2b86f2b"
+  VERSION = '0.6.0-c4'.freeze
+  LIBRDKAFKA_VERSION = '1.3.0'.freeze
+  # SHA256 checksum for tar.gz can be found here https://github.com/edenhill/librdkafka/releases
+  LIBRDKAFKA_SOURCE_SHA256 =
+    '465cab533ebc5b9ca8d97c90ab69e0093460665ebaf38623209cf343653c76d2'.freeze
 end


### PR DESCRIPTION
- [x] @johnny-lai 

https://coupadev.atlassian.net/browse/CD-183087 - Upgrade librdkafka to the latest.

- Upgrade librdkafka to release 1.2.2-RC1
- Includes the timespec_get fix for MacOSX10.15.sdk for development.
- Added comments on where to find the checksum.
- I froze the constants to keep my local rubocop quiet.