### PR TITLE
CD-183575 Provide a way to disable the logs and stats callbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ rvm:
 branches:
   only:
   - master
+  - releases/v0.6.0-c3
 
 before_install:
   - gem update --system

--- a/examples/sand/sand_consumer.rb
+++ b/examples/sand/sand_consumer.rb
@@ -52,6 +52,9 @@ if !params.has_key?(:group) || !params.has_key?(:topic)
   exit 1
 end
 
+Rdkafka::Config.attach_rdkafka_log_cb = false
+Rdkafka::Config.attach_rdkafka_stats_cb = false
+
 cfg = Rdkafka::Config.new(
   "bootstrap.servers": params[:"bootstrap-server"],
   "group.id": params[:group],

--- a/spec/rdkafka/config_spec.rb
+++ b/spec/rdkafka/config_spec.rb
@@ -20,6 +20,19 @@ describe Rdkafka::Config do
     end
   end
 
+  context "attach_rdkafka_log_cb" do
+    it "should default to true" do
+      expect(Rdkafka::Config.attach_rdkafka_log_cb).to eq true
+    end
+
+    it "should be settable" do
+      Rdkafka::Config.attach_rdkafka_log_cb = false
+      expect(Rdkafka::Config.attach_rdkafka_log_cb).to eq false
+      Rdkafka::Config.attach_rdkafka_log_cb = true
+      expect(Rdkafka::Config.attach_rdkafka_log_cb).to eq true
+    end
+  end
+
   context "statistics callback" do
     it "should set the callback" do
       expect {
@@ -34,6 +47,19 @@ describe Rdkafka::Config do
       expect {
         Rdkafka::Config.statistics_callback = 'a string'
       }.to raise_error(TypeError)
+    end
+  end
+
+  context "attach_rdkafka_stats_cb" do
+    it "should default to true" do
+      expect(Rdkafka::Config.attach_rdkafka_stats_cb).to eq true
+    end
+
+    it "should be settable" do
+      Rdkafka::Config.attach_rdkafka_stats_cb = false
+      expect(Rdkafka::Config.attach_rdkafka_stats_cb).to eq false
+      Rdkafka::Config.attach_rdkafka_stats_cb = true
+      expect(Rdkafka::Config.attach_rdkafka_stats_cb).to eq true
     end
   end
 


### PR DESCRIPTION
- [x] @johnwu96822 
- [x] @abdollar 

Log callbacks into Ruby causes deadlocks during oauth sometimes.