### PR TITLE
CD-237765 Fix issue where calling query_watermark_offsets immediately…

### DIFF
--- a/spec/rdkafka/admin_operations_spec.rb
+++ b/spec/rdkafka/admin_operations_spec.rb
@@ -91,11 +91,11 @@ describe "AdminOperations" do
         partition: 0
       ).wait
 
-      low, high = consumer.query_watermark_offsets("watermarks_test_topic", 0, 5000)
+      low, high = consumer.query_watermark_offsets("watermarks_test_topic", 0, timeout: 5)
       expect(low).to eq 0
       expect(high).to be > 0
 
-      low, high = producer.query_watermark_offsets("watermarks_test_topic", 0, 5000)
+      low, high = producer.query_watermark_offsets("watermarks_test_topic", 0, timeout: 5)
       expect(low).to eq 0
       expect(high).to be > 0
     end
@@ -103,14 +103,14 @@ describe "AdminOperations" do
     it "should raise an error when consumer querying offsets fails" do
       expect(Rdkafka::Bindings).to receive(:rd_kafka_query_watermark_offsets).and_return(20)
       expect {
-        consumer.query_watermark_offsets("consume_test_topic", 0, 5000)
+        consumer.query_watermark_offsets("consume_test_topic", 0)
       }.to raise_error Rdkafka::RdkafkaError
     end
 
     it "should raise an error when producer querying offsets fails" do
       expect(Rdkafka::Bindings).to receive(:rd_kafka_query_watermark_offsets).and_return(20)
       expect {
-        producer.query_watermark_offsets("consume_test_topic", 0, 5000)
+        producer.query_watermark_offsets("consume_test_topic", 0)
       }.to raise_error Rdkafka::RdkafkaError
     end
   end

--- a/spec/rdkafka/consumer_spec.rb
+++ b/spec/rdkafka/consumer_spec.rb
@@ -427,7 +427,7 @@ describe Rdkafka::Consumer do
         partition: 0
       ).wait
 
-      low, high = consumer.query_watermark_offsets("watermarks_test_topic", 0, 5000)
+      low, high = consumer.query_watermark_offsets("watermarks_test_topic", 0)
       expect(low).to eq 0
       expect(high).to be > 0
     end
@@ -435,7 +435,7 @@ describe Rdkafka::Consumer do
     it "should raise an error when querying offsets fails" do
       expect(Rdkafka::Bindings).to receive(:rd_kafka_query_watermark_offsets).and_return(20)
       expect {
-        consumer.query_watermark_offsets("consume_test_topic", 0, 5000)
+        consumer.query_watermark_offsets("consume_test_topic", 0)
       }.to raise_error Rdkafka::RdkafkaError
     end
   end


### PR DESCRIPTION
… after producer is created with oauth hangs

* Adjusted the timeout parameter to match the other functions

- [x] @abdulchaudhrycoupa 